### PR TITLE
[refactor] Update SvelteLDClient to use proxy for flag variations. Allows to track flag evaluations

### DIFF
--- a/packages/sdk/svelte/__tests__/lib/client/SvelteLDClient.test.ts
+++ b/packages/sdk/svelte/__tests__/lib/client/SvelteLDClient.test.ts
@@ -18,7 +18,7 @@ const mockLDClient = {
   on: (e: string, cb: () => void) => mockLDEventEmitter.on(e, cb),
   off: vi.fn(),
   allFlags: vi.fn().mockReturnValue(rawFlags),
-  variation: vi.fn(),
+  variation: vi.fn((_, defaultValue) => defaultValue),
   identify: vi.fn(),
 };
 
@@ -129,6 +129,9 @@ describe('launchDarkly', () => {
         ld.initialize(clientSideID);
         const flagStore = ld.watch(booleanFlagKey);
         const flagStore2 = ld.watch(stringFlagKey);
+
+        // emit ready event to set initial flag values
+        mockLDEventEmitter.emit('ready');
 
         // 'test-flag' initial value is true according to `rawFlags`
         expect(get(flagStore)).toBe(true);

--- a/packages/sdk/svelte/package.json
+++ b/packages/sdk/svelte/package.json
@@ -44,13 +44,11 @@
   },
   "peerDependencies": {
     "@launchdarkly/js-client-sdk": "workspace:^",
-    "@launchdarkly/js-client-sdk-common": "^1.10.0",
     "@launchdarkly/node-server-sdk": "^9.4.6",
     "svelte": "^4.0.0"
   },
   "dependencies": {
     "@launchdarkly/js-client-sdk": "workspace:^",
-    "@launchdarkly/js-client-sdk-common": "1.10.0",
     "esm-env": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request includes several significant changes to the `SvelteLDClient` in the `svelte` SDK package. The changes focus on improving the handling of flag variations, updating dependencies, and adding a new proxy mechanism for flag access.

Improvements to flag variation handling:

* [`packages/sdk/svelte/src/lib/client/SvelteLDClient.ts`](diffhunk://#diff-09afdc17d67731212d354e1c0f017e554f71988164f3ab8ce707a5b3bd542347R30-R66): Added a new `toFlagsProxy` function to create a proxy for the flags object, which intercepts access to flag values and returns the appropriate variation. This ensures that the flag values are correctly fetched from the LaunchDarkly client.

Updates to dependencies:

* [`packages/sdk/svelte/package.json`](diffhunk://#diff-2065b0c1245fd39f9187d0d39ace4700f818587fb5b26dfc2fd1231a3d424664L47-L53): Removed `@launchdarkly/js-client-sdk-common` from both `peerDependencies` and `dependencies`.

Enhancements to test cases:

* [`packages/sdk/svelte/__tests__/lib/client/SvelteLDClient.test.ts`](diffhunk://#diff-1a6bc0c5b386f33f82382714995ef9d493af4c44065dade636007d4bc10096afL21-R21): Modified the `variation` mock to return the default value and added an event emission for the 'ready' event to set initial flag values in the test cases. [[1]](diffhunk://#diff-1a6bc0c5b386f33f82382714995ef9d493af4c44065dade636007d4bc10096afL21-R21) [[2]](diffhunk://#diff-1a6bc0c5b386f33f82382714995ef9d493af4c44065dade636007d4bc10096afR133-R135)

Refactoring for consistency:

* [`packages/sdk/svelte/src/lib/client/SvelteLDClient.ts`](diffhunk://#diff-09afdc17d67731212d354e1c0f017e554f71988164f3ab8ce707a5b3bd542347L46-R87): Replaced references to `jsSdk` with `coreLdClient` for consistency and clarity in the `createLD` function. [[1]](diffhunk://#diff-09afdc17d67731212d354e1c0f017e554f71988164f3ab8ce707a5b3bd542347L46-R87) [[2]](diffhunk://#diff-09afdc17d67731212d354e1c0f017e554f71988164f3ab8ce707a5b3bd542347L69-R103) [[3]](diffhunk://#diff-09afdc17d67731212d354e1c0f017e554f71988164f3ab8ce707a5b3bd542347L87-R120)